### PR TITLE
Update validate.sh

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -6,7 +6,7 @@ dataFactoryResourceId=$2
 cd $dataFactoryDir
 ls -l
 
-echo "Installing Azure Data Factory Utilities package..."\
+echo "Installing Azure Data Factory Utilities package..."
 npm install @microsoft/azure-data-factory-utilities
 echo "Installation completed."
 


### PR DESCRIPTION
Removed \ that was causing npm install not to run. 

This action keeps failing for me in GitHub actions and I'm pretty sure it's due to this erroneous \ on line 9.  Can you please consider doing a new release with this fix in it?