### PR TITLE
Trigger fail action when there is a validation error

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -12,4 +12,13 @@ echo "Installation completed."
 
 echo "Validating $dataFactoryResourceId at $(pwd)..."
 node ./node_modules/@microsoft/azure-data-factory-utilities/lib/index validate $(pwd) $dataFactoryResourceId
-echo "Validation completed."
+status=$?
+
+if [ $? -eq 0 ]
+then
+  echo "Validation completed."
+  exit 0
+else
+  echo "Validation completed with errors" >&2
+  exit 1
+fi

--- a/validate.sh
+++ b/validate.sh
@@ -14,7 +14,7 @@ echo "Validating $dataFactoryResourceId at $(pwd)..."
 node ./node_modules/@microsoft/azure-data-factory-utilities/lib/index validate $(pwd) $dataFactoryResourceId
 status=$?
 
-if [ $? -eq 0 ]
+if [ $status -eq 0 ]
 then
   echo "Validation completed."
   exit 0

--- a/validate.sh
+++ b/validate.sh
@@ -19,6 +19,6 @@ then
   echo "Validation completed."
   exit 0
 else
-  echo "Validation completed with errors" >&2
+  echo "Validation completed with errors." >&2
   exit 1
 fi


### PR DESCRIPTION
Hi there,

I'm making some modifications to the `validation.sh` script to solve the issue where having a failed validations result in a successful action (Resolves #2).

If by the case the user still wants the failed validation to be considered success, they can use [continue-on-error](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) to prevent the job from failing when this step fails.