### PR TITLE
Update to supported version of NodeJS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.6.2-stretch-slim
+FROM node:18.20.3-buster-slim
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
The upstream npm package for [@microsoft/azure-data-factory-utilities](https://www.npmjs.com/package/@microsoft/azure-data-factory-utilities) requires NodeJS 18.x

Changes:
- bumps node container version to 18.20.3-buster-slim